### PR TITLE
Feature/differentiate region and city

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -40,13 +40,13 @@ def crawl(regionArgument):
     regions = regionArgument.split(',')
     for region in regions:
         try:
-            yield runner.crawl(EervastSpider, queryCity=region)
+            yield runner.crawl(EervastSpider, queryRegion=region)
         except NotSupported:
             print 'skipped spider'
 
-        yield runner.crawl(DomicaSpider, queryCity=region)
-        yield runner.crawl(NederwoonSpider, queryCity=region)
-        yield runner.crawl(EenTweeDrieWonenSpider, queryCity=region)
+        yield runner.crawl(DomicaSpider, queryRegion=region)
+        yield runner.crawl(NederwoonSpider, queryRegion=region)
+        yield runner.crawl(EenTweeDrieWonenSpider, queryRegion=region)
 
 
     reactor.stop()

--- a/scrapper/spider/__init__.py
+++ b/scrapper/spider/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ["domica", "eentweedriewonen", "eervast", "nederwoon"]

--- a/scrapper/spider/domica.py
+++ b/scrapper/spider/domica.py
@@ -10,7 +10,7 @@ class DomicaSpider(scrapy.Spider):
     allowed_domains = ["www.domica.nl"]
 
     def __init__(self, queryRegion='Amersfoort'):
-        self.region = queryRegion
+        self.region = queryRegion.title()
         self.start_urls = [
             (
                 'https://www.domica.nl/woningaanbod/huur/land-nederland/gemeente-{0}/type-appartement'

--- a/scrapper/spider/domica.py
+++ b/scrapper/spider/domica.py
@@ -9,11 +9,11 @@ class DomicaSpider(scrapy.Spider):
     name = 'domicaspider'
     allowed_domains = ["www.domica.nl"]
 
-    def __init__(self, queryCity='Amersfoort'):
+    def __init__(self, queryRegion='Amersfoort'):
         self.start_urls = [
             (
                 'https://www.domica.nl/woningaanbod/huur/land-nederland/gemeente-{0}/type-appartement'
-                .format(queryCity)
+                .format(queryRegion)
             )
         ]
 

--- a/scrapper/spider/domica.py
+++ b/scrapper/spider/domica.py
@@ -10,6 +10,7 @@ class DomicaSpider(scrapy.Spider):
     allowed_domains = ["www.domica.nl"]
 
     def __init__(self, queryRegion='Amersfoort'):
+        self.region = queryRegion
         self.start_urls = [
             (
                 'https://www.domica.nl/woningaanbod/huur/land-nederland/gemeente-{0}/type-appartement'
@@ -64,6 +65,7 @@ class DomicaSpider(scrapy.Spider):
         yield {
             'street': street,
             'city': city,
+            'region': self.region,
             'volume': volume,
             'rooms': rooms,
             'availability': response.meta['availability'],

--- a/scrapper/spider/eentweedriewonen.py
+++ b/scrapper/spider/eentweedriewonen.py
@@ -9,11 +9,11 @@ class EenTweeDrieWonenSpider(scrapy.Spider):
     name = '123WonenSpider'
     allowed_domains = ["www.123wonen.nl"]
 
-    def __init__(self, queryCity='Amersfoort'):
+    def __init__(self, queryRegion='Amersfoort'):
         self.start_urls = [
             (
                 'https://www.123wonen.nl/aanbod?per-page=50&city={0}&radius=10&residence_type_id=6'
-                .format(queryCity)
+                .format(queryRegion)
             )
         ]
 

--- a/scrapper/spider/eentweedriewonen.py
+++ b/scrapper/spider/eentweedriewonen.py
@@ -10,7 +10,7 @@ class EenTweeDrieWonenSpider(scrapy.Spider):
     allowed_domains = ["www.123wonen.nl"]
 
     def __init__(self, queryRegion='Amersfoort'):
-        self.region = queryRegion
+        self.region = queryRegion.title()
         self.start_urls = [
             (
                 'https://www.123wonen.nl/aanbod?per-page=50&city={0}&radius=10&residence_type_id=6'

--- a/scrapper/spider/eentweedriewonen.py
+++ b/scrapper/spider/eentweedriewonen.py
@@ -10,6 +10,7 @@ class EenTweeDrieWonenSpider(scrapy.Spider):
     allowed_domains = ["www.123wonen.nl"]
 
     def __init__(self, queryRegion='Amersfoort'):
+        self.region = queryRegion
         self.start_urls = [
             (
                 'https://www.123wonen.nl/aanbod?per-page=50&city={0}&radius=10&residence_type_id=6'
@@ -70,6 +71,7 @@ class EenTweeDrieWonenSpider(scrapy.Spider):
         yield {
             'street': street,
             'city': city,
+            'region': self.region,
             'volume': volume,
             'rooms': rooms,
             'availability': availability,

--- a/scrapper/spider/eervast.py
+++ b/scrapper/spider/eervast.py
@@ -23,8 +23,9 @@ class EervastSpider(scrapy.Spider):
     name = 'eervastspider'
     allowed_domains = ["www.eervast.nl"]
 
-    def __init__(self, queryCity='amersfoort'):
-        if queryCity.lower() != 'amersfoort':
+    def __init__(self, queryRegion='amersfoort'):
+        self.region = queryRegion
+        if queryRegion.lower() != 'amersfoort':
             raise NotSupported
 
     def build_request(self, type):
@@ -73,6 +74,7 @@ class EervastSpider(scrapy.Spider):
         yield {
             'street': response.meta['street'],
             'city': response.meta['city'],
+            'region': self.region,
             'volume': volume,
             'rooms': rooms,
             'availability': availability,

--- a/scrapper/spider/eervast.py
+++ b/scrapper/spider/eervast.py
@@ -24,7 +24,7 @@ class EervastSpider(scrapy.Spider):
     allowed_domains = ["www.eervast.nl"]
 
     def __init__(self, queryRegion='amersfoort'):
-        self.region = queryRegion
+        self.region = queryRegion.title()
         if queryRegion.lower() != 'amersfoort':
             raise NotSupported
 

--- a/scrapper/spider/nederwoon.py
+++ b/scrapper/spider/nederwoon.py
@@ -10,6 +10,7 @@ class NederwoonSpider(scrapy.Spider):
     allowed_domains = ["www.nederwoon.nl"]
 
     def __init__(self, queryRegion='amersfoort'):
+        self.region = queryRegion
         self.start_urls = ['http://www.nederwoon.nl/huurwoningen/{0}?numberviews=1000&rows=1000&q='.format(queryRegion)]
 
     def parse(self, response):
@@ -41,6 +42,7 @@ class NederwoonSpider(scrapy.Spider):
         yield {
             'street': cityStreet[0],
             'city': cityStreet[1],
+            'region': self.region,
             'volume': volume,
             'rooms': rooms,
             'availability': response.meta['Availability'],

--- a/scrapper/spider/nederwoon.py
+++ b/scrapper/spider/nederwoon.py
@@ -10,7 +10,7 @@ class NederwoonSpider(scrapy.Spider):
     allowed_domains = ["www.nederwoon.nl"]
 
     def __init__(self, queryRegion='amersfoort'):
-        self.region = queryRegion
+        self.region = queryRegion.title()
         self.start_urls = ['http://www.nederwoon.nl/huurwoningen/{0}?numberviews=1000&rows=1000&q='.format(queryRegion)]
 
     def parse(self, response):

--- a/scrapper/spider/nederwoon.py
+++ b/scrapper/spider/nederwoon.py
@@ -9,8 +9,8 @@ class NederwoonSpider(scrapy.Spider):
     name = 'nederwoonspider'
     allowed_domains = ["www.nederwoon.nl"]
 
-    def __init__(self, queryCity='amersfoort'):
-        self.start_urls = [('http://www.nederwoon.nl/huurwoningen/{0}?numberviews=1000&rows=1000&q='.format(queryCity))]
+    def __init__(self, queryRegion='amersfoort'):
+        self.start_urls = ['http://www.nederwoon.nl/huurwoningen/{0}?numberviews=1000&rows=1000&q='.format(queryRegion)]
 
     def parse(self, response):
         pageSelector = Selector(response)


### PR DESCRIPTION
The crawler will now save the Region's for each result. Because the query region might be different than the city of the result. If we keep this data we can achieve a cheap mapping for sorting results by regions